### PR TITLE
Dtportal 14813 handling php72 incompatibilities by notifications

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -229,6 +229,7 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
+trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: preg_replace() - \/e modifier is deprecated since PHP 5.5 and removed since PHP 7.0", E_USER_WARNING);
 $content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
 
 // Make the file end by EOL

--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -229,7 +229,7 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: preg_replace() - \/e modifier is deprecated since PHP 5.5 and removed since PHP 7.0", E_USER_WARNING);
+trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: preg_replace() - \/e modifier is deprecated since PHP 5.5 and removed since PHP 7.0\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
 $content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
 
 // Make the file end by EOL

--- a/library/Zend/Amf/Parse/Resource/MysqlResult.php
+++ b/library/Zend/Amf/Parse/Resource/MysqlResult.php
@@ -50,15 +50,19 @@ class Zend_Amf_Parse_Resource_MysqlResult
      */
     public function parse($resource) {
         $result = array();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
         $fieldcnt = mysql_num_fields($resource);
         $fields_transform = array();
         for($i=0;$i<$fieldcnt;$i++) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
             $type = mysql_field_type($resource, $i);
             if(isset(self::$fieldTypes[$type])) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
                 $fields_transform[mysql_field_name($resource, $i)] = self::$fieldTypes[$type];
             }
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
         while($row = mysql_fetch_object($resource)) {
             foreach($fields_transform as $fieldname => $fieldtype) {
                settype($row->$fieldname, $fieldtype);

--- a/library/Zend/Amf/Parse/Resource/MysqlResult.php
+++ b/library/Zend/Amf/Parse/Resource/MysqlResult.php
@@ -50,19 +50,19 @@ class Zend_Amf_Parse_Resource_MysqlResult
      */
     public function parse($resource) {
         $result = array();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $fieldcnt = mysql_num_fields($resource);
         $fields_transform = array();
         for($i=0;$i<$fieldcnt;$i++) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $type = mysql_field_type($resource, $i);
             if(isset(self::$fieldTypes[$type])) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 $fields_transform[mysql_field_name($resource, $i)] = self::$fieldTypes[$type];
             }
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'mysql_' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         while($row = mysql_fetch_object($resource)) {
             foreach($fields_transform as $fieldname => $fieldtype) {
                settype($row->$fieldname, $fieldtype);

--- a/library/Zend/Amf/Parse/Serializer.php
+++ b/library/Zend/Amf/Parse/Serializer.php
@@ -53,6 +53,7 @@ abstract class Zend_Amf_Parse_Serializer
     public function __construct(Zend_Amf_Parse_OutputStream $stream)
     {
         $this->_stream = $stream;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
         $this->_mbStringFunctionsOverloaded = function_exists('mb_strlen') && (ini_get('mbstring.func_overload') !== '') && ((int)ini_get('mbstring.func_overload') & 2);
     }
 

--- a/library/Zend/Amf/Parse/Serializer.php
+++ b/library/Zend/Amf/Parse/Serializer.php
@@ -53,7 +53,7 @@ abstract class Zend_Amf_Parse_Serializer
     public function __construct(Zend_Amf_Parse_OutputStream $stream)
     {
         $this->_stream = $stream;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->_mbStringFunctionsOverloaded = function_exists('mb_strlen') && (ini_get('mbstring.func_overload') !== '') && ((int)ini_get('mbstring.func_overload') & 2);
     }
 

--- a/library/Zend/Amf/Util/BinaryStream.php
+++ b/library/Zend/Amf/Util/BinaryStream.php
@@ -74,7 +74,7 @@ class Zend_Amf_Util_BinaryStream
 
         $this->_stream       = $stream;
         $this->_needle       = 0;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->_mbStringFunctionsOverloaded = function_exists('mb_strlen') && (ini_get('mbstring.func_overload') !== '') && ((int)ini_get('mbstring.func_overload') & 2);
         $this->_streamLength = $this->_mbStringFunctionsOverloaded ? mb_strlen($stream, '8bit') : strlen($stream);
         $this->_bigEndian    = (pack('l', 1) === "\x00\x00\x00\x01");

--- a/library/Zend/Amf/Util/BinaryStream.php
+++ b/library/Zend/Amf/Util/BinaryStream.php
@@ -74,6 +74,7 @@ class Zend_Amf_Util_BinaryStream
 
         $this->_stream       = $stream;
         $this->_needle       = 0;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
         $this->_mbStringFunctionsOverloaded = function_exists('mb_strlen') && (ini_get('mbstring.func_overload') !== '') && ((int)ini_get('mbstring.func_overload') & 2);
         $this->_streamLength = $this->_mbStringFunctionsOverloaded ? mb_strlen($stream, '8bit') : strlen($stream);
         $this->_bigEndian    = (pack('l', 1) === "\x00\x00\x00\x01");

--- a/library/Zend/Cache/Backend/Sqlite.php
+++ b/library/Zend/Cache/Backend/Sqlite.php
@@ -100,6 +100,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
      */
     public function __destruct()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         @sqlite_close($this->_getConnection());
     }
 
@@ -118,6 +119,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             $sql = $sql . " AND (expire=0 OR expire>" . time() . ')';
         }
         $result = $this->_query($sql);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if ($row) {
             return $row['content'];
@@ -136,6 +138,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $sql = "SELECT lastModified FROM cache WHERE id='$id' AND (expire=0 OR expire>" . time() . ')';
         $result = $this->_query($sql);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if ($row) {
             return ((int) $row['lastModified']);
@@ -160,6 +163,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $this->_checkAndBuildStructure();
         $lifetime = $this->getLifetime($specificLifetime);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $data = @sqlite_escape_string($data);
         $mktime = time();
         if ($lifetime === null) {
@@ -191,6 +195,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT COUNT(*) AS nbr FROM cache WHERE id='$id'");
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $result1 = @sqlite_fetch_single($res);
         $result2 = $this->_query("DELETE FROM cache WHERE id='$id'");
         $result3 = $this->_query("DELETE FROM tag WHERE id='$id'");
@@ -233,6 +238,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT id FROM cache WHERE (expire=0 OR expire>" . time() . ")");
         $result = array();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         while ($id = @sqlite_fetch_single($res)) {
             $result[] = $id;
         }
@@ -249,6 +255,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT DISTINCT(name) AS name FROM tag");
         $result = array();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         while ($id = @sqlite_fetch_single($res)) {
             $result[] = $id;
         }
@@ -272,6 +279,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             if (!$res) {
                 return array();
             }
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             $ids2 = array();
             foreach ($rows as $row) {
@@ -302,6 +310,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     public function getIdsNotMatchingTags($tags = array())
     {
         $res = $this->_query("SELECT id FROM cache");
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
         $result = array();
         foreach ($rows as $row) {
@@ -312,6 +321,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
                 if (!$res) {
                     return array();
                 }
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
                 $nbr = (int) @sqlite_fetch_single($res);
                 if ($nbr > 0) {
                     $matching = true;
@@ -341,6 +351,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             if (!$res) {
                 return array();
             }
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             $ids2 = array();
             foreach ($rows as $row) {
@@ -397,6 +408,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $tags = array();
         $res = $this->_query("SELECT name FROM tag WHERE id='$id'");
         if ($res) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             foreach ($rows as $row) {
                 $tags[] = $row['name'];
@@ -407,6 +419,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (!$res) {
             return false;
         }
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $row = @sqlite_fetch_array($res, SQLITE_ASSOC);
         return array(
             'tags' => $tags,
@@ -429,6 +442,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (!$res) {
             return false;
         }
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $expire = @sqlite_fetch_single($res);
         $newExpire = $expire + $extraLifetime;
         $res = $this->_query("UPDATE cache SET lastModified=" . time() . ", expire=$newExpire WHERE id='$id'");
@@ -491,6 +505,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (is_resource($this->_db)) {
             return $this->_db;
         } else {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
             $this->_db = @sqlite_open($this->_options['cache_db_complete_path']);
             if (!(is_resource($this->_db))) {
                 Zend_Cache::throwException("Impossible to open " . $this->_options['cache_db_complete_path'] . " cache DB file");
@@ -509,6 +524,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $db = $this->_getConnection();
         if (is_resource($db)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
             $res = @sqlite_query($db, $query);
             if ($res === false) {
                 return false;
@@ -582,6 +598,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $result = $this->_query("SELECT num FROM version");
         if (!$result) return false;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if (!$row) {
             return false;

--- a/library/Zend/Cache/Backend/Sqlite.php
+++ b/library/Zend/Cache/Backend/Sqlite.php
@@ -100,7 +100,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
      */
     public function __destruct()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @sqlite_close($this->_getConnection());
     }
 
@@ -119,7 +119,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             $sql = $sql . " AND (expire=0 OR expire>" . time() . ')';
         }
         $result = $this->_query($sql);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if ($row) {
             return $row['content'];
@@ -138,7 +138,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $sql = "SELECT lastModified FROM cache WHERE id='$id' AND (expire=0 OR expire>" . time() . ')';
         $result = $this->_query($sql);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if ($row) {
             return ((int) $row['lastModified']);
@@ -163,7 +163,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $this->_checkAndBuildStructure();
         $lifetime = $this->getLifetime($specificLifetime);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $data = @sqlite_escape_string($data);
         $mktime = time();
         if ($lifetime === null) {
@@ -195,7 +195,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT COUNT(*) AS nbr FROM cache WHERE id='$id'");
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $result1 = @sqlite_fetch_single($res);
         $result2 = $this->_query("DELETE FROM cache WHERE id='$id'");
         $result3 = $this->_query("DELETE FROM tag WHERE id='$id'");
@@ -238,7 +238,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT id FROM cache WHERE (expire=0 OR expire>" . time() . ")");
         $result = array();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         while ($id = @sqlite_fetch_single($res)) {
             $result[] = $id;
         }
@@ -255,7 +255,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $this->_checkAndBuildStructure();
         $res = $this->_query("SELECT DISTINCT(name) AS name FROM tag");
         $result = array();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         while ($id = @sqlite_fetch_single($res)) {
             $result[] = $id;
         }
@@ -279,7 +279,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             if (!$res) {
                 return array();
             }
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             $ids2 = array();
             foreach ($rows as $row) {
@@ -310,7 +310,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     public function getIdsNotMatchingTags($tags = array())
     {
         $res = $this->_query("SELECT id FROM cache");
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
         $result = array();
         foreach ($rows as $row) {
@@ -321,7 +321,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
                 if (!$res) {
                     return array();
                 }
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 $nbr = (int) @sqlite_fetch_single($res);
                 if ($nbr > 0) {
                     $matching = true;
@@ -351,7 +351,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
             if (!$res) {
                 return array();
             }
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             $ids2 = array();
             foreach ($rows as $row) {
@@ -408,7 +408,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         $tags = array();
         $res = $this->_query("SELECT name FROM tag WHERE id='$id'");
         if ($res) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $rows = @sqlite_fetch_all($res, SQLITE_ASSOC);
             foreach ($rows as $row) {
                 $tags[] = $row['name'];
@@ -419,7 +419,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (!$res) {
             return false;
         }
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $row = @sqlite_fetch_array($res, SQLITE_ASSOC);
         return array(
             'tags' => $tags,
@@ -442,7 +442,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (!$res) {
             return false;
         }
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $expire = @sqlite_fetch_single($res);
         $newExpire = $expire + $extraLifetime;
         $res = $this->_query("UPDATE cache SET lastModified=" . time() . ", expire=$newExpire WHERE id='$id'");
@@ -505,7 +505,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (is_resource($this->_db)) {
             return $this->_db;
         } else {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $this->_db = @sqlite_open($this->_options['cache_db_complete_path']);
             if (!(is_resource($this->_db))) {
                 Zend_Cache::throwException("Impossible to open " . $this->_options['cache_db_complete_path'] . " cache DB file");
@@ -524,7 +524,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $db = $this->_getConnection();
         if (is_resource($db)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $res = @sqlite_query($db, $query);
             if ($res === false) {
                 return false;
@@ -598,7 +598,7 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     {
         $result = $this->_query("SELECT num FROM version");
         if (!$result) return false;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Extension 'sqlite' is removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $row = @sqlite_fetch_array($result);
         if (!$row) {
             return false;

--- a/library/Zend/Crypt/Math.php
+++ b/library/Zend/Crypt/Math.php
@@ -81,7 +81,7 @@ class Zend_Crypt_Math extends Zend_Crypt_Math_BigInteger
             return random_bytes($length);
         }
         if (function_exists('mcrypt_create_iv')) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $bytes = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
             if ($bytes !== false && strlen($bytes) === $length) {
                 return $bytes;

--- a/library/Zend/Crypt/Math.php
+++ b/library/Zend/Crypt/Math.php
@@ -81,6 +81,7 @@ class Zend_Crypt_Math extends Zend_Crypt_Math_BigInteger
             return random_bytes($length);
         }
         if (function_exists('mcrypt_create_iv')) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             $bytes = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
             if ($bytes !== false && strlen($bytes) === $length) {
                 return $bytes;

--- a/library/Zend/Feed.php
+++ b/library/Zend/Feed.php
@@ -257,6 +257,7 @@ class Zend_Feed
      */
     public static function importFile($filename)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename);
         @ini_restore('track_errors');
@@ -297,6 +298,7 @@ class Zend_Feed
         $contents = $response->getBody();
 
         // Parse the contents for appropriate <link ... /> tags
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $pattern = '~(<link[^>]+)/?>~i';
         $result = @preg_match_all($pattern, $contents, $matches);

--- a/library/Zend/Feed.php
+++ b/library/Zend/Feed.php
@@ -257,7 +257,7 @@ class Zend_Feed
      */
     public static function importFile($filename)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename);
         @ini_restore('track_errors');
@@ -298,7 +298,7 @@ class Zend_Feed
         $contents = $response->getBody();
 
         // Parse the contents for appropriate <link ... /> tags
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $pattern = '~(<link[^>]+)/?>~i';
         $result = @preg_match_all($pattern, $contents, $matches);

--- a/library/Zend/Feed/Abstract.php
+++ b/library/Zend/Feed/Abstract.php
@@ -111,7 +111,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      */
     public function __wakeup()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $doc = new DOMDocument;
         $doc = @Zend_Xml_Security::scan($this->_element, $doc);
@@ -119,7 +119,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
 
         if (!$doc) {
             // prevent the class to generate an undefined variable notice (ZF-2590)
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             if (!isset($php_errormsg)) {
                 if (function_exists('xdebug_is_enabled')) {
                     $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Abstract.php
+++ b/library/Zend/Feed/Abstract.php
@@ -111,6 +111,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      */
     public function __wakeup()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $doc = new DOMDocument;
         $doc = @Zend_Xml_Security::scan($this->_element, $doc);
@@ -118,6 +119,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
 
         if (!$doc) {
             // prevent the class to generate an undefined variable notice (ZF-2590)
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
             if (!isset($php_errormsg)) {
                 if (function_exists('xdebug_is_enabled')) {
                     $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Entry/Abstract.php
+++ b/library/Zend/Feed/Entry/Abstract.php
@@ -80,6 +80,7 @@ abstract class Zend_Feed_Entry_Abstract extends Zend_Feed_Element
         if (!($element instanceof DOMElement)) {
             if ($element) {
                 // Load the feed as an XML DOMDocument object
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
                 @ini_set('track_errors', 1);
                 $doc = new DOMDocument();
                 $doc = @Zend_Xml_Security::scan($element, $doc);
@@ -87,6 +88,7 @@ abstract class Zend_Feed_Entry_Abstract extends Zend_Feed_Element
 
                 if (!$doc) {
                     // prevent the class to generate an undefined variable notice (ZF-2590)
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
                     if (!isset($php_errormsg)) {
                         if (function_exists('xdebug_is_enabled')) {
                             $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Entry/Abstract.php
+++ b/library/Zend/Feed/Entry/Abstract.php
@@ -80,7 +80,7 @@ abstract class Zend_Feed_Entry_Abstract extends Zend_Feed_Element
         if (!($element instanceof DOMElement)) {
             if ($element) {
                 // Load the feed as an XML DOMDocument object
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 @ini_set('track_errors', 1);
                 $doc = new DOMDocument();
                 $doc = @Zend_Xml_Security::scan($element, $doc);
@@ -88,7 +88,7 @@ abstract class Zend_Feed_Entry_Abstract extends Zend_Feed_Element
 
                 if (!$doc) {
                     // prevent the class to generate an undefined variable notice (ZF-2590)
-                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                     if (!isset($php_errormsg)) {
                         if (function_exists('xdebug_is_enabled')) {
                             $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Entry/Atom.php
+++ b/library/Zend/Feed/Entry/Atom.php
@@ -194,7 +194,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
         }
 
         // Update internal properties using $client->responseBody;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $newEntry = new DOMDocument;
         $newEntry = @Zend_Xml_Security::scan($response->getBody(), $newEntry);
@@ -202,7 +202,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
 
         if (!$newEntry) {
             // prevent the class to generate an undefined variable notice (ZF-2590)
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             if (!isset($php_errormsg)) {
                 if (function_exists('xdebug_is_enabled')) {
                     $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Entry/Atom.php
+++ b/library/Zend/Feed/Entry/Atom.php
@@ -194,6 +194,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
         }
 
         // Update internal properties using $client->responseBody;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $newEntry = new DOMDocument;
         $newEntry = @Zend_Xml_Security::scan($response->getBody(), $newEntry);
@@ -201,6 +202,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
 
         if (!$newEntry) {
             // prevent the class to generate an undefined variable notice (ZF-2590)
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
             if (!isset($php_errormsg)) {
                 if (function_exists('xdebug_is_enabled')) {
                     $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Reader.php
+++ b/library/Zend/Feed/Reader.php
@@ -388,6 +388,7 @@ class Zend_Feed_Reader
      */
     public static function importFile($filename)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename);
         @ini_restore('track_errors');
@@ -454,6 +455,7 @@ class Zend_Feed_Reader
         } elseif($feed instanceof DOMDocument) {
             $dom = $feed;
         } elseif(is_string($feed) && !empty($feed)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             @ini_set('track_errors', 1);
             //$oldValue = libxml_disable_entity_loader(true);
             $dom = new DOMDocument;
@@ -468,6 +470,7 @@ class Zend_Feed_Reader
             //libxml_disable_entity_loader($oldValue);
             @ini_restore('track_errors');
             if (!$dom) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
                 if (!isset($php_errormsg)) {
                     if (function_exists('xdebug_is_enabled')) {
                         $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Feed/Reader.php
+++ b/library/Zend/Feed/Reader.php
@@ -388,7 +388,7 @@ class Zend_Feed_Reader
      */
     public static function importFile($filename)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename);
         @ini_restore('track_errors');
@@ -455,7 +455,7 @@ class Zend_Feed_Reader
         } elseif($feed instanceof DOMDocument) {
             $dom = $feed;
         } elseif(is_string($feed) && !empty($feed)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             @ini_set('track_errors', 1);
             //$oldValue = libxml_disable_entity_loader(true);
             $dom = new DOMDocument;
@@ -470,7 +470,7 @@ class Zend_Feed_Reader
             //libxml_disable_entity_loader($oldValue);
             @ini_restore('track_errors');
             if (!$dom) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 if (!isset($php_errormsg)) {
                     if (function_exists('xdebug_is_enabled')) {
                         $php_errormsg = '(error message not available, when XDebug is running)';

--- a/library/Zend/Filter/Boolean.php
+++ b/library/Zend/Filter/Boolean.php
@@ -89,7 +89,7 @@ class Zend_Filter_Boolean implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } elseif (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/Boolean.php
+++ b/library/Zend/Filter/Boolean.php
@@ -89,6 +89,7 @@ class Zend_Filter_Boolean implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } elseif (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/Callback.php
+++ b/library/Zend/Filter/Callback.php
@@ -57,7 +57,7 @@ class Zend_Filter_Callback implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options) || !array_key_exists('callback', $options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options          = func_get_args();
             $temp['callback'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/Callback.php
+++ b/library/Zend/Filter/Callback.php
@@ -57,6 +57,7 @@ class Zend_Filter_Callback implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options) || !array_key_exists('callback', $options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options          = func_get_args();
             $temp['callback'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/Encrypt/Mcrypt.php
+++ b/library/Zend/Filter/Encrypt/Mcrypt.php
@@ -123,21 +123,21 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
         }
 
         $options = $options + $this->getEncryption();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_algorithms() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_algorithms() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $algorithms = mcrypt_list_algorithms($options['algorithm_directory']);
         if (!in_array($options['algorithm'], $algorithms)) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception("The algorithm '{$options['algorithm']}' is not supported");
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_modes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_modes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $modes = mcrypt_list_modes($options['mode_directory']);
         if (!in_array($options['mode'], $modes)) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception("The mode '{$options['mode']}' is not supported");
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_self_test() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_self_test() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (!mcrypt_module_self_test($options['algorithm'], $options['algorithm_directory'])) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception('The given algorithm can not be used due an internal mcrypt problem');
@@ -172,26 +172,26 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     public function setVector($vector = null)
     {
         $cipher = $this->_openCipher();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_iv_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_iv_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $size   = mcrypt_enc_get_iv_size($cipher);
         if (empty($vector)) {
             $this->_srand();
             if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && version_compare(PHP_VERSION, '5.3.0', '<')) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 $method = MCRYPT_RAND;
             } else {
                 if (file_exists('/dev/urandom') || (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')) {
-                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                     $method = MCRYPT_DEV_URANDOM;
                 } elseif (file_exists('/dev/random')) {
-                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_RANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_RANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                     $method = MCRYPT_DEV_RANDOM;
                 } else {
-                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                     $method = MCRYPT_RAND;
                 }
             }
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $vector = mcrypt_create_iv($size, $method);
         } else if (strlen($vector) != $size) {
             require_once 'Zend/Filter/Exception.php';
@@ -249,9 +249,9 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
 
         $cipher  = $this->_openCipher();
         $this->_initCipher($cipher);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $encrypted = mcrypt_generic($cipher, $value);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         mcrypt_generic_deinit($cipher);
         $this->_closeCipher($cipher);
 
@@ -270,9 +270,9 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     {
         $cipher = $this->_openCipher();
         $this->_initCipher($cipher);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mdecrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mdecrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $decrypted = mdecrypt_generic($cipher, $value);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         mcrypt_generic_deinit($cipher);
         $this->_closeCipher($cipher);
 
@@ -304,7 +304,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
      */
     protected function _openCipher()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_open() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_open() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $cipher = mcrypt_module_open(
             $this->_encryption['algorithm'],
             $this->_encryption['algorithm_directory'],
@@ -327,7 +327,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
      */
     protected function _closeCipher($cipher)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_close() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_close() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         mcrypt_module_close($cipher);
 
         return $this;
@@ -344,11 +344,11 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     {
         $key = $this->_encryption['key'];
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_supported_key_sizes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_supported_key_sizes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $keysizes = mcrypt_enc_get_supported_key_sizes($cipher);
         if (empty($keysizes) || ($this->_encryption['salt'] == true)) {
             $this->_srand();
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_key_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_key_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $keysize = mcrypt_enc_get_key_size($cipher);
             $key     = substr(md5($key), 0, $keysize);
         } else if (!in_array(strlen($key), $keysizes)) {
@@ -356,7 +356,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
             throw new Zend_Filter_Exception('The given key has a wrong size for the set algorithm');
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_init() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_init() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $result = mcrypt_generic_init($cipher, $key, $this->_encryption['vector']);
         if ($result < 0) {
             require_once 'Zend/Filter/Exception.php';

--- a/library/Zend/Filter/Encrypt/Mcrypt.php
+++ b/library/Zend/Filter/Encrypt/Mcrypt.php
@@ -123,18 +123,21 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
         }
 
         $options = $options + $this->getEncryption();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_algorithms() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $algorithms = mcrypt_list_algorithms($options['algorithm_directory']);
         if (!in_array($options['algorithm'], $algorithms)) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception("The algorithm '{$options['algorithm']}' is not supported");
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_list_modes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $modes = mcrypt_list_modes($options['mode_directory']);
         if (!in_array($options['mode'], $modes)) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception("The mode '{$options['mode']}' is not supported");
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_self_test() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         if (!mcrypt_module_self_test($options['algorithm'], $options['algorithm_directory'])) {
             require_once 'Zend/Filter/Exception.php';
             throw new Zend_Filter_Exception('The given algorithm can not be used due an internal mcrypt problem');
@@ -169,20 +172,26 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     public function setVector($vector = null)
     {
         $cipher = $this->_openCipher();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_iv_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $size   = mcrypt_enc_get_iv_size($cipher);
         if (empty($vector)) {
             $this->_srand();
             if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && version_compare(PHP_VERSION, '5.3.0', '<')) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 $method = MCRYPT_RAND;
             } else {
                 if (file_exists('/dev/urandom') || (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')) {
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_URANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                     $method = MCRYPT_DEV_URANDOM;
                 } elseif (file_exists('/dev/random')) {
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_DEV_RANDOM\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                     $method = MCRYPT_DEV_RANDOM;
                 } else {
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RAND\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                     $method = MCRYPT_RAND;
                 }
             }
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_create_iv() is deprecated since PHP 7.1 and removed since PHP 7.2; Use random_bytes() or OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
             $vector = mcrypt_create_iv($size, $method);
         } else if (strlen($vector) != $size) {
             require_once 'Zend/Filter/Exception.php';
@@ -240,7 +249,9 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
 
         $cipher  = $this->_openCipher();
         $this->_initCipher($cipher);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $encrypted = mcrypt_generic($cipher, $value);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         mcrypt_generic_deinit($cipher);
         $this->_closeCipher($cipher);
 
@@ -259,7 +270,9 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     {
         $cipher = $this->_openCipher();
         $this->_initCipher($cipher);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mdecrypt_generic() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead", E_USER_WARNING);
         $decrypted = mdecrypt_generic($cipher, $value);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_deinit() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         mcrypt_generic_deinit($cipher);
         $this->_closeCipher($cipher);
 
@@ -291,6 +304,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
      */
     protected function _openCipher()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_open() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $cipher = mcrypt_module_open(
             $this->_encryption['algorithm'],
             $this->_encryption['algorithm_directory'],
@@ -313,6 +327,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
      */
     protected function _closeCipher($cipher)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_module_close() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         mcrypt_module_close($cipher);
 
         return $this;
@@ -329,9 +344,11 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
     {
         $key = $this->_encryption['key'];
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_supported_key_sizes() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $keysizes = mcrypt_enc_get_supported_key_sizes($cipher);
         if (empty($keysizes) || ($this->_encryption['salt'] == true)) {
             $this->_srand();
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_enc_get_key_size() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
             $keysize = mcrypt_enc_get_key_size($cipher);
             $key     = substr(md5($key), 0, $keysize);
         } else if (!in_array(strlen($key), $keysizes)) {
@@ -339,6 +356,7 @@ class Zend_Filter_Encrypt_Mcrypt implements Zend_Filter_Encrypt_Interface
             throw new Zend_Filter_Exception('The given key has a wrong size for the set algorithm');
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_generic_init() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $result = mcrypt_generic_init($cipher, $key, $this->_encryption['vector']);
         if ($result < 0) {
             require_once 'Zend/Filter/Exception.php';

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -63,6 +63,7 @@ class Zend_Filter_File_Rename implements Zend_Filter_Interface
         }
 
         if (1 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $source    = array_shift($argv);

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -63,7 +63,7 @@ class Zend_Filter_File_Rename implements Zend_Filter_Interface
         }
 
         if (1 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $source    = array_shift($argv);

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -65,6 +65,7 @@ class Zend_Filter_HtmlEntities implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['quotestyle'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -65,7 +65,7 @@ class Zend_Filter_HtmlEntities implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['quotestyle'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/Inflector.php
+++ b/library/Zend/Filter/Inflector.php
@@ -75,7 +75,7 @@ class Zend_Filter_Inflector implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
 

--- a/library/Zend/Filter/Inflector.php
+++ b/library/Zend/Filter/Inflector.php
@@ -75,6 +75,7 @@ class Zend_Filter_Inflector implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
 

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -65,7 +65,7 @@ class Zend_Filter_Null implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -65,6 +65,7 @@ class Zend_Filter_Null implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -89,7 +89,7 @@ class Zend_Filter_PregReplace implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -89,6 +89,7 @@ class Zend_Filter_PregReplace implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -49,6 +49,7 @@ class Zend_Filter_StringToLower implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -49,7 +49,7 @@ class Zend_Filter_StringToLower implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -49,7 +49,7 @@ class Zend_Filter_StringToUpper implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -49,6 +49,7 @@ class Zend_Filter_StringToUpper implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Filter/StringTrim.php
+++ b/library/Zend/Filter/StringTrim.php
@@ -53,7 +53,7 @@ class Zend_Filter_StringTrim implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options          = func_get_args();
             $temp['charlist'] = array_shift($options);
             $options          = $temp;

--- a/library/Zend/Filter/StringTrim.php
+++ b/library/Zend/Filter/StringTrim.php
@@ -53,6 +53,7 @@ class Zend_Filter_StringTrim implements Zend_Filter_Interface
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options          = func_get_args();
             $temp['charlist'] = array_shift($options);
             $options          = $temp;

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -86,7 +86,7 @@ class Zend_Filter_StripTags implements Zend_Filter_Interface
             $options = $options->toArray();
         } else if ((!is_array($options)) || (is_array($options) && !array_key_exists('allowTags', $options) &&
             !array_key_exists('allowAttribs', $options) && !array_key_exists('allowComments', $options))) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['allowTags'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -86,6 +86,7 @@ class Zend_Filter_StripTags implements Zend_Filter_Interface
             $options = $options->toArray();
         } else if ((!is_array($options)) || (is_array($options) && !array_key_exists('allowTags', $options) &&
             !array_key_exists('allowAttribs', $options) && !array_key_exists('allowComments', $options))) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['allowTags'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Gdata/App.php
+++ b/library/Zend/Gdata/App.php
@@ -823,6 +823,7 @@ class Zend_Gdata_App
         }
 
         // Load the feed as an XML DOMDocument object
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $doc = new DOMDocument();
         $doc = @Zend_Xml_Security::scan($string, $doc);
@@ -855,6 +856,7 @@ class Zend_Gdata_App
     public static function importFile($filename,
             $className='Zend_Gdata_App_Feed', $useIncludePath = false)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename, $useIncludePath);
         @ini_restore('track_errors');

--- a/library/Zend/Gdata/App.php
+++ b/library/Zend/Gdata/App.php
@@ -823,7 +823,7 @@ class Zend_Gdata_App
         }
 
         // Load the feed as an XML DOMDocument object
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $doc = new DOMDocument();
         $doc = @Zend_Xml_Security::scan($string, $doc);
@@ -856,7 +856,7 @@ class Zend_Gdata_App
     public static function importFile($filename,
             $className='Zend_Gdata_App_Feed', $useIncludePath = false)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         @ini_set('track_errors', 1);
         $feed = @file_get_contents($filename, $useIncludePath);
         @ini_restore('track_errors');

--- a/library/Zend/Gdata/App/Base.php
+++ b/library/Zend/Gdata/App/Base.php
@@ -302,7 +302,7 @@ abstract class Zend_Gdata_App_Base
     {
         if ($xml) {
             // Load the feed as an XML DOMDocument object
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             @ini_set('track_errors', 1);
             $doc = new DOMDocument();
             $doc = @Zend_Xml_Security::scan($xml, $doc);

--- a/library/Zend/Gdata/App/Base.php
+++ b/library/Zend/Gdata/App/Base.php
@@ -302,6 +302,7 @@ abstract class Zend_Gdata_App_Base
     {
         if ($xml) {
             // Load the feed as an XML DOMDocument object
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             @ini_set('track_errors', 1);
             $doc = new DOMDocument();
             $doc = @Zend_Xml_Security::scan($xml, $doc);

--- a/library/Zend/Gdata/Gapps/ServiceException.php
+++ b/library/Zend/Gdata/Gapps/ServiceException.php
@@ -161,7 +161,7 @@ class Zend_Gdata_Gapps_ServiceException extends Zend_Exception
             // track_errors is temporarily enabled so that if an error
             // occurs while parsing the XML we can append it to an
             // exception by referencing $php_errormsg
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             @ini_set('track_errors', 1);
             $doc = new DOMDocument();
             $doc = @Zend_Xml_Security::scan($string, $doc);

--- a/library/Zend/Gdata/Gapps/ServiceException.php
+++ b/library/Zend/Gdata/Gapps/ServiceException.php
@@ -161,6 +161,7 @@ class Zend_Gdata_Gapps_ServiceException extends Zend_Exception
             // track_errors is temporarily enabled so that if an error
             // occurs while parsing the XML we can append it to an
             // exception by referencing $php_errormsg
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             @ini_set('track_errors', 1);
             $doc = new DOMDocument();
             $doc = @Zend_Xml_Security::scan($string, $doc);

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1273,8 +1273,8 @@ class Zend_Http_Client
         }
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
         if (function_exists('mb_internal_encoding') &&
-           trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
            ((int) ini_get('mbstring.func_overload')) & 2) {
 
             $mbIntEnc = mb_internal_encoding();

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1273,7 +1273,7 @@ class Zend_Http_Client
         }
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (function_exists('mb_internal_encoding') &&
            ((int) ini_get('mbstring.func_overload')) & 2) {
 

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1274,6 +1274,7 @@ class Zend_Http_Client
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
         if (function_exists('mb_internal_encoding') &&
+           trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
            ((int) ini_get('mbstring.func_overload')) & 2) {
 
             $mbIntEnc = mb_internal_encoding();

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -602,8 +602,8 @@ class Zend_Http_Response
 
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
         if (function_exists('mb_internal_encoding') &&
-           trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
            ((int) ini_get('mbstring.func_overload')) & 2) {
 
             $mbIntEnc = mb_internal_encoding();

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -602,7 +602,7 @@ class Zend_Http_Response
 
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (function_exists('mb_internal_encoding') &&
            ((int) ini_get('mbstring.func_overload')) & 2) {
 

--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -603,6 +603,7 @@ class Zend_Http_Response
         // If mbstring overloads substr and strlen functions, we have to
         // override it's internal encoding
         if (function_exists('mb_internal_encoding') &&
+           trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
            ((int) ini_get('mbstring.func_overload')) & 2) {
 
             $mbIntEnc = mb_internal_encoding();

--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -100,6 +100,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
 
         $argv = null;
         if (2 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 2);
         }
@@ -143,6 +144,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
     {
         $argv = null;
         if (3 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 3);
         }

--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -100,7 +100,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
 
         $argv = null;
         if (2 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 2);
         }
@@ -144,7 +144,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
     {
         $argv = null;
         if (3 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 3);
         }

--- a/library/Zend/Ldap.php
+++ b/library/Zend/Ldap.php
@@ -991,7 +991,7 @@ class Zend_Ldap
             throw new Zend_Ldap_Exception($this, 'searching: ' . $filter);
         }
         if ($sort !== null && is_string($sort)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Function ldap_sort() is deprecated since PHP 7.0", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Function ldap_sort() is deprecated since PHP 7.0\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $isSorted = @ldap_sort($this->getResource(), $search, $sort);
             if($isSorted === false) {
                 /**

--- a/library/Zend/Ldap.php
+++ b/library/Zend/Ldap.php
@@ -991,6 +991,7 @@ class Zend_Ldap
             throw new Zend_Ldap_Exception($this, 'searching: ' . $filter);
         }
         if ($sort !== null && is_string($sort)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Function ldap_sort() is deprecated since PHP 7.0", E_USER_WARNING);
             $isSorted = @ldap_sort($this->getResource(), $search, $sort);
             if($isSorted === false) {
                 /**

--- a/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -200,6 +200,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
 
         $entry = array('dn' => $this->key());
         $ber_identifier = null;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_first_attribute() is removed since PHP 5.2.4", E_USER_WARNING);
         $name = @ldap_first_attribute($this->_ldap->getResource(), $this->_current,
             $ber_identifier);
         while ($name) {
@@ -221,6 +222,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
                     break;
             }
             $entry[$attrName] = $data;
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_next_attribute() is removed since PHP 5.2.4", E_USER_WARNING);
             $name = @ldap_next_attribute($this->_ldap->getResource(), $this->_current,
                 $ber_identifier);
         }

--- a/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -200,7 +200,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
 
         $entry = array('dn' => $this->key());
         $ber_identifier = null;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_first_attribute() is removed since PHP 5.2.4", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_first_attribute() is removed since PHP 5.2.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $name = @ldap_first_attribute($this->_ldap->getResource(), $this->_current,
             $ber_identifier);
         while ($name) {
@@ -222,7 +222,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
                     break;
             }
             $entry[$attrName] = $data;
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_next_attribute() is removed since PHP 5.2.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The \"ber_identifier\" parameter for function ldap_next_attribute() is removed since PHP 5.2.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $name = @ldap_next_attribute($this->_ldap->getResource(), $this->_current,
                 $ber_identifier);
         }

--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -1334,6 +1334,7 @@ class Zend_Locale_Format
     protected static function _setEncoding($encoding)
     {
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', $encoding);
         } else {
             ini_set('default_charset', $encoding);

--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -1334,7 +1334,7 @@ class Zend_Locale_Format
     protected static function _setEncoding($encoding)
     {
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', $encoding);
         } else {
             ini_set('default_charset', $encoding);

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -60,7 +60,7 @@ class Zend_Log_Formatter_Xml extends Zend_Log_Formatter_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } elseif (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args = func_get_args();
 
             $options = array(

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -60,6 +60,7 @@ class Zend_Log_Formatter_Xml extends Zend_Log_Formatter_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } elseif (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args = func_get_args();
 
             $options = array(

--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -407,6 +407,7 @@ class Zend_Mail_Protocol_Imap
             }
         }
         $result = array();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         foreach (func_get_args() as $string) {
             $result[] = $this->escapeString($string);
         }

--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -407,7 +407,7 @@ class Zend_Mail_Protocol_Imap
             }
         }
         $result = array();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         foreach (func_get_args() as $string) {
             $result[] = $this->escapeString($string);
         }

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -746,7 +746,7 @@ class Zend_OpenId
      */
     static public function strlen($str)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (extension_loaded('mbstring') &&
             (((int)ini_get('mbstring.func_overload')) & 2)) {
             return mb_strlen($str, 'latin1');

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -747,6 +747,7 @@ class Zend_OpenId
     static public function strlen($str)
     {
         if (extension_loaded('mbstring') &&
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
             (((int)ini_get('mbstring.func_overload')) & 2)) {
             return mb_strlen($str, 'latin1');
         } else {

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -746,8 +746,8 @@ class Zend_OpenId
      */
     static public function strlen($str)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
         if (extension_loaded('mbstring') &&
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'mbstring.func_overload' is deprecated since PHP 7.2", E_USER_WARNING);
             (((int)ini_get('mbstring.func_overload')) & 2)) {
             return mb_strlen($str, 'latin1');
         } else {

--- a/library/Zend/Pdf/Filter/Compression/Flate.php
+++ b/library/Zend/Pdf/Filter/Compression/Flate.php
@@ -47,20 +47,20 @@ class Zend_Pdf_Filter_Compression_Flate extends Zend_Pdf_Filter_Compression
         }
 
         if (extension_loaded('zlib')) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $trackErrors = ini_get( "track_errors");
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', '1');
 
             if (($output = @gzcompress($data)) === false) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 ini_set('track_errors', $trackErrors);
                 require_once 'Zend/Pdf/Exception.php';
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 throw new Zend_Pdf_Exception($php_errormsg);
             }
 
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
         } else {
             require_once 'Zend/Pdf/Exception.php';
@@ -80,24 +80,24 @@ class Zend_Pdf_Filter_Compression_Flate extends Zend_Pdf_Filter_Compression
      */
     public static function decode($data, $params = null)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         global $php_errormsg;
 
         if (extension_loaded('zlib')) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $trackErrors = ini_get( "track_errors");
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', '1');
 
             if (($output = @gzuncompress($data)) === false) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 ini_set('track_errors', $trackErrors);
                 require_once 'Zend/Pdf/Exception.php';
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 throw new Zend_Pdf_Exception($php_errormsg);
             }
 
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
         } else {
             require_once 'Zend/Pdf/Exception.php';

--- a/library/Zend/Pdf/Filter/Compression/Flate.php
+++ b/library/Zend/Pdf/Filter/Compression/Flate.php
@@ -47,15 +47,20 @@ class Zend_Pdf_Filter_Compression_Flate extends Zend_Pdf_Filter_Compression
         }
 
         if (extension_loaded('zlib')) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             $trackErrors = ini_get( "track_errors");
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', '1');
 
             if (($output = @gzcompress($data)) === false) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
                 ini_set('track_errors', $trackErrors);
                 require_once 'Zend/Pdf/Exception.php';
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
                 throw new Zend_Pdf_Exception($php_errormsg);
             }
 
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
         } else {
             require_once 'Zend/Pdf/Exception.php';
@@ -75,18 +80,24 @@ class Zend_Pdf_Filter_Compression_Flate extends Zend_Pdf_Filter_Compression
      */
     public static function decode($data, $params = null)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
         global $php_errormsg;
 
         if (extension_loaded('zlib')) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             $trackErrors = ini_get( "track_errors");
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', '1');
 
             if (($output = @gzuncompress($data)) === false) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
                 ini_set('track_errors', $trackErrors);
                 require_once 'Zend/Pdf/Exception.php';
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
                 throw new Zend_Pdf_Exception($php_errormsg);
             }
 
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
         } else {
             require_once 'Zend/Pdf/Exception.php';

--- a/library/Zend/Search/Lucene.php
+++ b/library/Zend/Search/Lucene.php
@@ -985,6 +985,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
         } else {
             // sort by given field names
 
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argList    = func_get_args();
             $fieldNames = $this->getFieldNames();
             $sortArgs   = array();

--- a/library/Zend/Search/Lucene.php
+++ b/library/Zend/Search/Lucene.php
@@ -985,7 +985,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
         } else {
             // sort by given field names
 
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argList    = func_get_args();
             $fieldNames = $this->getFieldNames();
             $sortArgs   = array();

--- a/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/library/Zend/Search/Lucene/MultiSearcher.php
@@ -218,6 +218,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function setDefaultSearchField($fieldName)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         foreach ($this->_indices as $index) {
             $index->setDefaultSearchField($fieldName);
         }
@@ -234,13 +235,16 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function getDefaultSearchField()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         if (count($this->_indices) == 0) {
             require_once 'Zend/Search/Lucene/Exception.php';
             throw new Zend_Search_Lucene_Exception('Indices list is empty');
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         $defaultSearchField = reset($this->_indices)->getDefaultSearchField();
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         foreach ($this->_indices as $index) {
             if ($index->getDefaultSearchField() !== $defaultSearchField) {
                 require_once 'Zend/Search/Lucene/Exception.php';
@@ -260,6 +264,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function setResultSetLimit($limit)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         foreach ($this->_indices as $index) {
             $index->setResultSetLimit($limit);
         }
@@ -275,13 +280,16 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function getResultSetLimit()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         if (count($this->_indices) == 0) {
             require_once 'Zend/Search/Lucene/Exception.php';
             throw new Zend_Search_Lucene_Exception('Indices list is empty');
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         $defaultResultSetLimit = reset($this->_indices)->getResultSetLimit();
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
         foreach ($this->_indices as $index) {
             if ($index->getResultSetLimit() !== $defaultResultSetLimit) {
                 require_once 'Zend/Search/Lucene/Exception.php';

--- a/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/library/Zend/Search/Lucene/MultiSearcher.php
@@ -218,7 +218,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function setDefaultSearchField($fieldName)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         foreach ($this->_indices as $index) {
             $index->setDefaultSearchField($fieldName);
         }
@@ -235,16 +235,16 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function getDefaultSearchField()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (count($this->_indices) == 0) {
             require_once 'Zend/Search/Lucene/Exception.php';
             throw new Zend_Search_Lucene_Exception('Indices list is empty');
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $defaultSearchField = reset($this->_indices)->getDefaultSearchField();
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         foreach ($this->_indices as $index) {
             if ($index->getDefaultSearchField() !== $defaultSearchField) {
                 require_once 'Zend/Search/Lucene/Exception.php';
@@ -264,7 +264,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function setResultSetLimit($limit)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         foreach ($this->_indices as $index) {
             $index->setResultSetLimit($limit);
         }
@@ -280,16 +280,16 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      */
     public static function getResultSetLimit()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if (count($this->_indices) == 0) {
             require_once 'Zend/Search/Lucene/Exception.php';
             throw new Zend_Search_Lucene_Exception('Indices list is empty');
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $defaultResultSetLimit = reset($this->_indices)->getResultSetLimit();
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be used in a plain function or method since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         foreach ($this->_indices as $index) {
             if ($index->getResultSetLimit() !== $defaultResultSetLimit) {
                 require_once 'Zend/Search/Lucene/Exception.php';

--- a/library/Zend/Search/Lucene/Storage/Directory/Filesystem.php
+++ b/library/Zend/Search/Lucene/Storage/Directory/Filesystem.php
@@ -207,14 +207,20 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
         }
         unset($this->_fileHandlers[$filename]);
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
         global $php_errormsg;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', '1');
         if (!@unlink($this->_dirPath . '/' . $filename)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception('Can\'t delete file: ' . $php_errormsg);
         }
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
     }
 
@@ -285,6 +291,7 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
      */
     public function renameFile($from, $to)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
         global $php_errormsg;
 
         if (isset($this->_fileHandlers[$from])) {
@@ -304,16 +311,21 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
             }
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', '1');
 
         $success = @rename($this->_dirPath . '/' . $from, $this->_dirPath . '/' . $to);
         if (!$success) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception($php_errormsg);
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
 
         return $success;

--- a/library/Zend/Search/Lucene/Storage/Directory/Filesystem.php
+++ b/library/Zend/Search/Lucene/Storage/Directory/Filesystem.php
@@ -207,20 +207,20 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
         }
         unset($this->_fileHandlers[$filename]);
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         global $php_errormsg;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', '1');
         if (!@unlink($this->_dirPath . '/' . $filename)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception('Can\'t delete file: ' . $php_errormsg);
         }
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
     }
 
@@ -291,7 +291,7 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
      */
     public function renameFile($from, $to)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         global $php_errormsg;
 
         if (isset($this->_fileHandlers[$from])) {
@@ -311,21 +311,21 @@ class Zend_Search_Lucene_Storage_Directory_Filesystem extends Zend_Search_Lucene
             }
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', '1');
 
         $success = @rename($this->_dirPath . '/' . $from, $this->_dirPath . '/' . $to);
         if (!$success) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception($php_errormsg);
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
 
         return $success;

--- a/library/Zend/Search/Lucene/Storage/File/Filesystem.php
+++ b/library/Zend/Search/Lucene/Storage/File/Filesystem.php
@@ -48,6 +48,7 @@ class Zend_Search_Lucene_Storage_File_Filesystem extends Zend_Search_Lucene_Stor
      */
     public function __construct($filename, $mode='r+b')
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
         global $php_errormsg;
 
         if (strpos($mode, 'w') === false  &&  !is_readable($filename)) {
@@ -56,17 +57,22 @@ class Zend_Search_Lucene_Storage_File_Filesystem extends Zend_Search_Lucene_Stor
             throw new Zend_Search_Lucene_Exception('File \'' . $filename . '\' is not readable.');
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', '1');
 
         $this->_fileHandle = @fopen($filename, $mode);
 
         if ($this->_fileHandle === false) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception($php_errormsg);
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
     }
 

--- a/library/Zend/Search/Lucene/Storage/File/Filesystem.php
+++ b/library/Zend/Search/Lucene/Storage/File/Filesystem.php
@@ -48,7 +48,7 @@ class Zend_Search_Lucene_Storage_File_Filesystem extends Zend_Search_Lucene_Stor
      */
     public function __construct($filename, $mode='r+b')
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         global $php_errormsg;
 
         if (strpos($mode, 'w') === false  &&  !is_readable($filename)) {
@@ -57,22 +57,22 @@ class Zend_Search_Lucene_Storage_File_Filesystem extends Zend_Search_Lucene_Stor
             throw new Zend_Search_Lucene_Exception('File \'' . $filename . '\' is not readable.');
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $trackErrors = ini_get('track_errors');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', '1');
 
         $this->_fileHandle = @fopen($filename, $mode);
 
         if ($this->_fileHandle === false) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             ini_set('track_errors', $trackErrors);
             require_once 'Zend/Search/Lucene/Exception.php';
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: The variable '\$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             throw new Zend_Search_Lucene_Exception($php_errormsg);
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'track_errors' is deprecated since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('track_errors', $trackErrors);
     }
 

--- a/library/Zend/Service/Audioscrobbler.php
+++ b/library/Zend/Service/Audioscrobbler.php
@@ -72,8 +72,11 @@ class Zend_Service_Audioscrobbler
         $this->set('version', '1.0');
 
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('output_encoding', 'UTF-8');
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('input_encoding', 'UTF-8');
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('output_encoding', 'UTF-8');

--- a/library/Zend/Service/Audioscrobbler.php
+++ b/library/Zend/Service/Audioscrobbler.php
@@ -72,11 +72,11 @@ class Zend_Service_Audioscrobbler
         $this->set('version', '1.0');
 
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('output_encoding', 'UTF-8');
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('input_encoding', 'UTF-8');
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('output_encoding', 'UTF-8');

--- a/library/Zend/Service/ReCaptcha/MailHide.php
+++ b/library/Zend/Service/ReCaptcha/MailHide.php
@@ -37,7 +37,9 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
     /**#@+
      * Encryption constants
      */
+    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
     const ENCRYPTION_MODE = MCRYPT_MODE_CBC;
+    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RIJNDAEL_128\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
     const ENCRYPTION_CIPHER = MCRYPT_RIJNDAEL_128;
     const ENCRYPTION_BLOCK_SIZE = 16;
     const ENCRYPTION_IV = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
@@ -343,6 +345,7 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
         $emailPadded = str_pad($this->_email, strlen($this->_email) + $numPad, chr($numPad));
 
         /* Encrypt the email */
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_encrypt() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
         $emailEncrypted = mcrypt_encrypt(self::ENCRYPTION_CIPHER, $this->_privateKeyPacked, $emailPadded, self::ENCRYPTION_MODE, self::ENCRYPTION_IV);
 
         /* Return the url */

--- a/library/Zend/Service/ReCaptcha/MailHide.php
+++ b/library/Zend/Service/ReCaptcha/MailHide.php
@@ -37,9 +37,7 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
     /**#@+
      * Encryption constants
      */
-    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
     const ENCRYPTION_MODE = MCRYPT_MODE_CBC;
-    trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RIJNDAEL_128\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
     const ENCRYPTION_CIPHER = MCRYPT_RIJNDAEL_128;
     const ENCRYPTION_BLOCK_SIZE = 16;
     const ENCRYPTION_IV = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
@@ -95,6 +93,9 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
      */
     public function __construct($publicKey = null, $privateKey = null, $email = null, $options = null)
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RIJNDAEL_128\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+
         /* Require the mcrypt extension to be loaded */
         $this->_requireMcrypt();
 

--- a/library/Zend/Service/ReCaptcha/MailHide.php
+++ b/library/Zend/Service/ReCaptcha/MailHide.php
@@ -93,8 +93,8 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
      */
     public function __construct($publicKey = null, $privateKey = null, $email = null, $options = null)
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RIJNDAEL_128\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_RIJNDAEL_128\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
 
         /* Require the mcrypt extension to be loaded */
         $this->_requireMcrypt();
@@ -346,7 +346,7 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
         $emailPadded = str_pad($this->_email, strlen($this->_email) + $numPad, chr($numPad));
 
         /* Encrypt the email */
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_encrypt() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Function mcrypt_encrypt() is deprecated since PHP 7.1 and removed since PHP 7.2; Use OpenSSL instead\n\tERROR: Extension 'mcrypt' is deprecated since PHP 7.1 and removed since PHP 7.2; Use openssl (preferred) or pecl\/mcrypt once available instead\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $emailEncrypted = mcrypt_encrypt(self::ENCRYPTION_CIPHER, $this->_privateKeyPacked, $emailPadded, self::ENCRYPTION_MODE, self::ENCRYPTION_IV);
 
         /* Return the url */

--- a/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -105,7 +105,7 @@ class Zend_Service_WindowsAzure_Storage_Batch
         unset($this->_operations);
         $this->_storageClient->setCurrentBatch(null);
         $this->_storageClient = null;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be unset since PHP 7.1.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be unset since PHP 7.1.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         unset($this);
     }
 

--- a/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -105,6 +105,7 @@ class Zend_Service_WindowsAzure_Storage_Batch
         unset($this->_operations);
         $this->_storageClient->setCurrentBatch(null);
         $this->_storageClient = null;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: \"\$this\" can no longer be unset since PHP 7.1.", E_USER_WARNING);
         unset($this);
     }
 

--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -531,6 +531,7 @@ class Zend_Session extends Zend_Session_Abstract
             }
         }
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1", E_USER_WARNING);
         $hashBitsPerChar = ini_get('session.hash_bits_per_character');
         if (!$hashBitsPerChar) {
             $hashBitsPerChar = 5; // the default value

--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -531,7 +531,7 @@ class Zend_Session extends Zend_Session_Abstract
             }
         }
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $hashBitsPerChar = ini_get('session.hash_bits_per_character');
         if (!$hashBitsPerChar) {
             $hashBitsPerChar = 5; // the default value

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -607,6 +607,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
 
         $this->_class = $class;
         if (1 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $this->_classArgs = $argv;

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -607,7 +607,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
 
         $this->_class = $class;
         if (1 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $this->_classArgs = $argv;

--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery34.php
@@ -159,6 +159,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery34 extends PHPUnit_Framework_Constrai
         $domQuery = new Zend_Dom_Query($other);
         $domQuery->registerXpathNamespaces($this->_xpathNamespaces);
         $result   = $domQuery->$method($this->_path);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery34.php
@@ -159,7 +159,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery34 extends PHPUnit_Framework_Constrai
         $domQuery = new Zend_Dom_Query($other);
         $domQuery->registerXpathNamespaces($this->_xpathNamespaces);
         $result   = $domQuery->$method($this->_path);
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect34.php
@@ -120,7 +120,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect34 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect34.php
@@ -120,6 +120,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect34 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
@@ -126,7 +126,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect37 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
@@ -126,6 +126,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect37 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
@@ -126,6 +126,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
@@ -126,7 +126,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit_Framework_Constrai
         $this->_assertType = $assertType;
 
         $response = $other;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader34.php
@@ -131,7 +131,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader34 extends PHPUnit_Framework_Co
         $this->_assertType = $assertType;
 
         $response = $other;
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader34.php
@@ -131,6 +131,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader34 extends PHPUnit_Framework_Co
         $this->_assertType = $assertType;
 
         $response = $other;
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
@@ -138,6 +138,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader37 extends PHPUnit_Framework_Co
 
         $this->_assertType = $assertType;
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
@@ -138,7 +138,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader37 extends PHPUnit_Framework_Co
 
         $this->_assertType = $assertType;
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
@@ -138,6 +138,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit_Framework_Co
 
         $this->_assertType = $assertType;
 
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
@@ -138,7 +138,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit_Framework_Co
 
         $this->_assertType = $assertType;
 
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $argv     = func_get_args();
         $argc     = func_num_args();
 

--- a/library/Zend/Tool/Framework/Client/Config.php
+++ b/library/Zend/Tool/Framework/Client/Config.php
@@ -39,6 +39,7 @@ class Zend_Tool_Framework_Client_Config
     /**
      * @param array $options
      */
+    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Method name \"Zend_Tool_Framework_Client_Config::__config\" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.", E_USER_WARNING);
     public function __config($options = array())
     {
         if ($options) {

--- a/library/Zend/Tool/Framework/Client/Config.php
+++ b/library/Zend/Tool/Framework/Client/Config.php
@@ -39,9 +39,9 @@ class Zend_Tool_Framework_Client_Config
     /**
      * @param array $options
      */
-    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Method name \"Zend_Tool_Framework_Client_Config::__config\" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.", E_USER_WARNING);
     public function __config($options = array())
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Method name \"Zend_Tool_Framework_Client_Config::__config\" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.", E_USER_WARNING);
         if ($options) {
             $this->setOptions($options);
         }

--- a/library/Zend/Tool/Framework/Client/Config.php
+++ b/library/Zend/Tool/Framework/Client/Config.php
@@ -41,7 +41,7 @@ class Zend_Tool_Framework_Client_Config
      */
     public function __config($options = array())
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Method name \"Zend_Tool_Framework_Client_Config::__config\" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Method name \"Zend_Tool_Framework_Client_Config::__config\" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         if ($options) {
             $this->setOptions($options);
         }

--- a/library/Zend/Translate.php
+++ b/library/Zend/Translate.php
@@ -73,7 +73,7 @@ class Zend_Translate {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['adapter'] = array_shift($args);
@@ -109,7 +109,7 @@ class Zend_Translate {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['adapter'] = array_shift($args);

--- a/library/Zend/Translate.php
+++ b/library/Zend/Translate.php
@@ -73,6 +73,7 @@ class Zend_Translate {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['adapter'] = array_shift($args);
@@ -108,6 +109,7 @@ class Zend_Translate {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['adapter'] = array_shift($args);

--- a/library/Zend/Translate/Adapter.php
+++ b/library/Zend/Translate/Adapter.php
@@ -130,6 +130,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);
@@ -199,6 +200,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);
@@ -588,6 +590,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args = func_get_args();
             $options['content'] = array_shift($args);
 

--- a/library/Zend/Translate/Adapter.php
+++ b/library/Zend/Translate/Adapter.php
@@ -130,7 +130,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);
@@ -200,7 +200,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);
@@ -590,7 +590,7 @@ abstract class Zend_Translate_Adapter {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args = func_get_args();
             $options['content'] = array_shift($args);
 

--- a/library/Zend/Translate/Adapter/Csv.php
+++ b/library/Zend/Translate/Adapter/Csv.php
@@ -51,7 +51,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);

--- a/library/Zend/Translate/Adapter/Csv.php
+++ b/library/Zend/Translate/Adapter/Csv.php
@@ -51,6 +51,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args               = func_get_args();
             $options            = array();
             $options['content'] = array_shift($args);

--- a/library/Zend/Validate/Between.php
+++ b/library/Zend/Validate/Between.php
@@ -101,6 +101,7 @@ class Zend_Validate_Between extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['min'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Between.php
+++ b/library/Zend/Validate/Between.php
@@ -101,7 +101,7 @@ class Zend_Validate_Between extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['min'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Callback.php
+++ b/library/Zend/Validate/Callback.php
@@ -155,6 +155,7 @@ class Zend_Validate_Callback extends Zend_Validate_Abstract
 
         $options  = $this->getOptions();
         $callback = $this->getCallback();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $args     = func_get_args();
         $options  = array_merge($args, $options);
 

--- a/library/Zend/Validate/Callback.php
+++ b/library/Zend/Validate/Callback.php
@@ -155,7 +155,7 @@ class Zend_Validate_Callback extends Zend_Validate_Abstract
 
         $options  = $this->getOptions();
         $callback = $this->getCallback();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $args     = func_get_args();
         $options  = array_merge($args, $options);
 

--- a/library/Zend/Validate/CreditCard.php
+++ b/library/Zend/Validate/CreditCard.php
@@ -143,6 +143,7 @@ class Zend_Validate_CreditCard extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['type'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/CreditCard.php
+++ b/library/Zend/Validate/CreditCard.php
@@ -143,7 +143,7 @@ class Zend_Validate_CreditCard extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['type'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Date.php
+++ b/library/Zend/Validate/Date.php
@@ -78,6 +78,7 @@ class Zend_Validate_Date extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['format'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Date.php
+++ b/library/Zend/Validate/Date.php
@@ -78,7 +78,7 @@ class Zend_Validate_Date extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['format'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Db/Abstract.php
+++ b/library/Zend/Validate/Db/Abstract.php
@@ -108,7 +108,7 @@ abstract class Zend_Validate_Db_Abstract extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options       = func_get_args();
             $temp['table'] = array_shift($options);
             $temp['field'] = array_shift($options);

--- a/library/Zend/Validate/Db/Abstract.php
+++ b/library/Zend/Validate/Db/Abstract.php
@@ -108,6 +108,7 @@ abstract class Zend_Validate_Db_Abstract extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (func_num_args() > 1) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options       = func_get_args();
             $temp['table'] = array_shift($options);
             $temp['field'] = array_shift($options);

--- a/library/Zend/Validate/EmailAddress.php
+++ b/library/Zend/Validate/EmailAddress.php
@@ -139,7 +139,7 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['allow'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/EmailAddress.php
+++ b/library/Zend/Validate/EmailAddress.php
@@ -139,6 +139,7 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['allow'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/File/Count.php
+++ b/library/Zend/Validate/File/Count.php
@@ -115,7 +115,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
         }
 
         if (1 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options['min'] = func_get_arg(0);
             $options['max'] = func_get_arg(1);
         }

--- a/library/Zend/Validate/File/Count.php
+++ b/library/Zend/Validate/File/Count.php
@@ -115,6 +115,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
         }
 
         if (1 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options['min'] = func_get_arg(0);
             $options['max'] = func_get_arg(1);
         }

--- a/library/Zend/Validate/File/FilesSize.php
+++ b/library/Zend/Validate/File/FilesSize.php
@@ -81,7 +81,7 @@ class Zend_Validate_File_FilesSize extends Zend_Validate_File_Size
         }
 
         if (1 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['max'] = array_shift($argv);

--- a/library/Zend/Validate/File/FilesSize.php
+++ b/library/Zend/Validate/File/FilesSize.php
@@ -81,6 +81,7 @@ class Zend_Validate_File_FilesSize extends Zend_Validate_File_Size
         }
 
         if (1 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['max'] = array_shift($argv);

--- a/library/Zend/Validate/File/ImageSize.php
+++ b/library/Zend/Validate/File/ImageSize.php
@@ -130,6 +130,7 @@ class Zend_Validate_File_ImageSize extends Zend_Validate_Abstract
             if (!is_array($options)) {
                 $options = array('minwidth' => $options);
             }
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['minheight'] = array_shift($argv);

--- a/library/Zend/Validate/File/ImageSize.php
+++ b/library/Zend/Validate/File/ImageSize.php
@@ -130,7 +130,7 @@ class Zend_Validate_File_ImageSize extends Zend_Validate_Abstract
             if (!is_array($options)) {
                 $options = array('minwidth' => $options);
             }
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['minheight'] = array_shift($argv);

--- a/library/Zend/Validate/File/MimeType.php
+++ b/library/Zend/Validate/File/MimeType.php
@@ -166,7 +166,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')
             && null === $this->_magicfile) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             if (!empty($_ENV['MAGIC'])) {
                 $this->setMagicFile($_ENV['MAGIC']);
             } elseif (

--- a/library/Zend/Validate/File/MimeType.php
+++ b/library/Zend/Validate/File/MimeType.php
@@ -166,10 +166,10 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')
             && null === $this->_magicfile) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4", E_USER_WARNING);
             if (!empty($_ENV['MAGIC'])) {
                 $this->setMagicFile($_ENV['MAGIC']);
             } elseif (
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4", E_USER_WARNING);
                 !(@ini_get("safe_mode") == 'On' || @ini_get("safe_mode") === 1)
                 && $this->shouldTryCommonMagicFiles() // @see ZF-11784
             ) {

--- a/library/Zend/Validate/File/MimeType.php
+++ b/library/Zend/Validate/File/MimeType.php
@@ -169,6 +169,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
             if (!empty($_ENV['MAGIC'])) {
                 $this->setMagicFile($_ENV['MAGIC']);
             } elseif (
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4\n\tWARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4", E_USER_WARNING);
                 !(@ini_get("safe_mode") == 'On' || @ini_get("safe_mode") === 1)
                 && $this->shouldTryCommonMagicFiles() // @see ZF-11784
             ) {

--- a/library/Zend/Validate/File/Size.php
+++ b/library/Zend/Validate/File/Size.php
@@ -113,7 +113,7 @@ class Zend_Validate_File_Size extends Zend_Validate_Abstract
         }
 
         if (1 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['max'] = array_shift($argv);

--- a/library/Zend/Validate/File/Size.php
+++ b/library/Zend/Validate/File/Size.php
@@ -113,6 +113,7 @@ class Zend_Validate_File_Size extends Zend_Validate_Abstract
         }
 
         if (1 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             array_shift($argv);
             $options['max'] = array_shift($argv);

--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -1522,7 +1522,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['allow'] = array_shift($options);
             if (!empty($options)) {
@@ -1740,7 +1740,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                         ? iconv_get_encoding('internal_encoding')
                         : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', 'UTF-8');
             } else {
                 ini_set('default_charset', 'UTF-8');
@@ -1849,7 +1849,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             } while (false);
 
             if (PHP_VERSION_ID < 50600) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', $origenc);
             } else {
                 ini_set('default_charset', $origenc);

--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -1522,6 +1522,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['allow'] = array_shift($options);
             if (!empty($options)) {
@@ -1739,6 +1740,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                         ? iconv_get_encoding('internal_encoding')
                         : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', 'UTF-8');
             } else {
                 ini_set('default_charset', 'UTF-8');
@@ -1847,6 +1849,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             } while (false);
 
             if (PHP_VERSION_ID < 50600) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', $origenc);
             } else {
                 ini_set('default_charset', $origenc);

--- a/library/Zend/Validate/InArray.php
+++ b/library/Zend/Validate/InArray.php
@@ -79,12 +79,12 @@ class Zend_Validate_InArray extends Zend_Validate_Abstract
             $count = func_num_args();
             $temp  = array();
             if ($count > 1) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 $temp['haystack'] = func_get_arg(0);
                 $temp['strict']   = func_get_arg(1);
                 $options = $temp;
             } else {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 $temp = func_get_arg(0);
                 if (!array_key_exists('haystack', $options)) {
                     $options = array();

--- a/library/Zend/Validate/InArray.php
+++ b/library/Zend/Validate/InArray.php
@@ -79,10 +79,12 @@ class Zend_Validate_InArray extends Zend_Validate_Abstract
             $count = func_num_args();
             $temp  = array();
             if ($count > 1) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
                 $temp['haystack'] = func_get_arg(0);
                 $temp['strict']   = func_get_arg(1);
                 $options = $temp;
             } else {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_arg(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
                 $temp = func_get_arg(0);
                 if (!array_key_exists('haystack', $options)) {
                     $options = array();

--- a/library/Zend/Validate/Ip.php
+++ b/library/Zend/Validate/Ip.php
@@ -63,7 +63,7 @@ class Zend_Validate_Ip extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp['allowipv6'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/Ip.php
+++ b/library/Zend/Validate/Ip.php
@@ -63,6 +63,7 @@ class Zend_Validate_Ip extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp['allowipv6'] = array_shift($options);
             if (!empty($options)) {

--- a/library/Zend/Validate/NotEmpty.php
+++ b/library/Zend/Validate/NotEmpty.php
@@ -90,7 +90,7 @@ class Zend_Validate_NotEmpty extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Validate/NotEmpty.php
+++ b/library/Zend/Validate/NotEmpty.php
@@ -90,6 +90,7 @@ class Zend_Validate_NotEmpty extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options = func_get_args();
             $temp    = array();
             if (!empty($options)) {

--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -86,6 +86,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $options     = func_get_args();
             $temp['min'] = array_shift($options);
             if (!empty($options)) {
@@ -204,6 +205,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
                         : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
                 if ($encoding) {
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
                     $result = iconv_set_encoding('internal_encoding', $encoding);
                 } else {
                     $result = false;
@@ -218,6 +220,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             }
 
             if (PHP_VERSION_ID < 50600) {
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', $orig);
             } else {
                 ini_set('default_charset', $orig);

--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -86,7 +86,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         } else if (!is_array($options)) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $options     = func_get_args();
             $temp['min'] = array_shift($options);
             if (!empty($options)) {
@@ -205,7 +205,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
                         : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
                 if ($encoding) {
-                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+                    trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                     $result = iconv_set_encoding('internal_encoding', $encoding);
                 } else {
                     $result = false;
@@ -220,7 +220,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             }
 
             if (PHP_VERSION_ID < 50600) {
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
                 iconv_set_encoding('internal_encoding', $orig);
             } else {
                 ini_set('default_charset', $orig);

--- a/library/Zend/View/Abstract.php
+++ b/library/Zend/View/Abstract.php
@@ -908,7 +908,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
         if (1 == func_num_args()) {
             return call_user_func($this->_escape, $var);
         }
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $args = func_get_args();
         return call_user_func_array($this->_escape, $args);
     }

--- a/library/Zend/View/Abstract.php
+++ b/library/Zend/View/Abstract.php
@@ -908,6 +908,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
         if (1 == func_num_args()) {
             return call_user_func($this->_escape, $var);
         }
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $args = func_get_args();
         return call_user_func_array($this->_escape, $args);
     }

--- a/library/Zend/View/Helper/Translate.php
+++ b/library/Zend/View/Helper/Translate.php
@@ -72,7 +72,7 @@ class Zend_View_Helper_Translate extends Zend_View_Helper_Abstract
         }
 
         $translate = $this->getTranslator();
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $options   = func_get_args();
 
         array_shift($options);

--- a/library/Zend/View/Helper/Translate.php
+++ b/library/Zend/View/Helper/Translate.php
@@ -72,6 +72,7 @@ class Zend_View_Helper_Translate extends Zend_View_Helper_Abstract
         }
 
         $translate = $this->getTranslator();
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
         $options   = func_get_args();
 
         array_shift($options);

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -258,11 +258,11 @@ class Zend_XmlRpc_Client
         $this->_lastRequest = $request;
 
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('input_encoding', 'UTF-8');
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('output_encoding', 'UTF-8');
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('input_encoding', 'UTF-8');

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -258,8 +258,11 @@ class Zend_XmlRpc_Client
         $this->_lastRequest = $request;
 
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('input_encoding', 'UTF-8');
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('output_encoding', 'UTF-8');
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('input_encoding', 'UTF-8');

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -239,7 +239,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
 
         $argv = null;
         if (2 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 2);
         }
@@ -281,7 +281,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
 
         $args = null;
         if (2 < func_num_args()) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $args = func_get_args();
             $args = array_slice($args, 2);
         }

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -239,6 +239,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
 
         $argv = null;
         if (2 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $argv = func_get_args();
             $argv = array_slice($argv, 2);
         }
@@ -280,6 +281,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
 
         $args = null;
         if (2 < func_num_args()) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value.", E_USER_WARNING);
             $args = func_get_args();
             $args = array_slice($args, 2);
         }

--- a/tests/Zend/Db/Adapter/TestCommon.php
+++ b/tests/Zend/Db/Adapter/TestCommon.php
@@ -1395,8 +1395,10 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
                 "Incorrect quote() BIGINT_TYPE result for decimal int string with leading zeroes");
 
             // test hex value with ODBC-style notation
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
             $value = $this->_db->quote('0x83215600', $typeName);
             $this->assertTrue(is_string($value));
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
             $this->assertEquals('0x83215600', $value,
                 "Incorrect quote() BIGINT_TYPE result for big hex int string");
 

--- a/tests/Zend/Db/Adapter/TestCommon.php
+++ b/tests/Zend/Db/Adapter/TestCommon.php
@@ -1395,10 +1395,10 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
                 "Incorrect quote() BIGINT_TYPE result for decimal int string with leading zeroes");
 
             // test hex value with ODBC-style notation
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $value = $this->_db->quote('0x83215600', $typeName);
             $this->assertTrue(is_string($value));
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $this->assertEquals('0x83215600', $value,
                 "Incorrect quote() BIGINT_TYPE result for big hex int string");
 

--- a/tests/Zend/Filter/DecryptTest.php
+++ b/tests/Zend/Filter/DecryptTest.php
@@ -141,13 +141,12 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $filter = new Zend_Filter_Decrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array(
                 'key'                 => 'testkey',
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'algorithm'           => MCRYPT_BLOWFISH,
                 'algorithm_directory' => '',
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'mode'                => MCRYPT_MODE_CBC,
                 'mode_directory'      => '',
                 'vector'              => 'testvect',
@@ -170,16 +169,14 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $filter = new Zend_Filter_Decrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $filter->setEncryption(
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array(
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'mode'                => MCRYPT_MODE_ECB,
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'algorithm'           => MCRYPT_3DES,
                 'key'                 => 'testkey',
                 'algorithm_directory' => '',

--- a/tests/Zend/Filter/DecryptTest.php
+++ b/tests/Zend/Filter/DecryptTest.php
@@ -141,7 +141,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $filter = new Zend_Filter_Decrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array(
                 'key'                 => 'testkey',
@@ -169,11 +169,11 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $filter = new Zend_Filter_Decrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $filter->setEncryption(
             array('mode' => MCRYPT_MODE_ECB,
                   'algorithm' => MCRYPT_3DES));
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array(
                 'mode'                => MCRYPT_MODE_ECB,

--- a/tests/Zend/Filter/DecryptTest.php
+++ b/tests/Zend/Filter/DecryptTest.php
@@ -144,8 +144,10 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $this->assertEquals(
             array(
                 'key'                 => 'testkey',
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'algorithm'           => MCRYPT_BLOWFISH,
                 'algorithm_directory' => '',
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'mode'                => MCRYPT_MODE_CBC,
                 'mode_directory'      => '',
                 'vector'              => 'testvect',
@@ -169,11 +171,15 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter = new Zend_Filter_Decrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
         $filter->setEncryption(
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
         $this->assertEquals(
             array(
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'mode'                => MCRYPT_MODE_ECB,
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                 'algorithm'           => MCRYPT_3DES,
                 'key'                 => 'testkey',
                 'algorithm_directory' => '',

--- a/tests/Zend/Filter/DigitsTest.php
+++ b/tests/Zend/Filter/DigitsTest.php
@@ -89,13 +89,13 @@ class Zend_Filter_DigitsTest extends PHPUnit_Framework_TestCase
         } else {
             // POSIX named classes are not supported, use alternative 0-9 match
             // Or filter for the value without mbstring
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
             $valuesExpected = array(
                 'abc123'  => '123',
                 'abc 123' => '123',
                 'abcxyz'  => '',
                 'AZ@#4.3' => '43',
                 '1.23'    => '123',
-                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
                 '0x9f'    => '09'
                 );
         }

--- a/tests/Zend/Filter/DigitsTest.php
+++ b/tests/Zend/Filter/DigitsTest.php
@@ -89,7 +89,7 @@ class Zend_Filter_DigitsTest extends PHPUnit_Framework_TestCase
         } else {
             // POSIX named classes are not supported, use alternative 0-9 match
             // Or filter for the value without mbstring
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             $valuesExpected = array(
                 'abc123'  => '123',
                 'abc 123' => '123',

--- a/tests/Zend/Filter/DigitsTest.php
+++ b/tests/Zend/Filter/DigitsTest.php
@@ -95,6 +95,7 @@ class Zend_Filter_DigitsTest extends PHPUnit_Framework_TestCase
                 'abcxyz'  => '',
                 'AZ@#4.3' => '43',
                 '1.23'    => '123',
+                trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
                 '0x9f'    => '09'
                 );
         }

--- a/tests/Zend/Filter/Encrypt/McryptTest.php
+++ b/tests/Zend/Filter/Encrypt/McryptTest.php
@@ -92,12 +92,11 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
     {
         $filter = new Zend_Filter_Encrypt_Mcrypt(array('key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_BLOWFISH,
                   'algorithm_directory' => '',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_CBC,
                   'mode_directory' => '',
                   'vector' => 'testvect',
@@ -115,17 +114,15 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
     {
         $filter = new Zend_Filter_Encrypt_Mcrypt(array('key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $filter->setEncryption(
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES,
                   'algorithm_directory' => '',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_ECB,
                   'mode_directory' => '',
                   'vector' => 'testvect',

--- a/tests/Zend/Filter/Encrypt/McryptTest.php
+++ b/tests/Zend/Filter/Encrypt/McryptTest.php
@@ -92,7 +92,7 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
     {
         $filter = new Zend_Filter_Encrypt_Mcrypt(array('key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
                   'algorithm' => MCRYPT_BLOWFISH,
@@ -114,11 +114,11 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
     {
         $filter = new Zend_Filter_Encrypt_Mcrypt(array('key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $filter->setEncryption(
             array('mode' => MCRYPT_MODE_ECB,
                   'algorithm' => MCRYPT_3DES));
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
                   'algorithm' => MCRYPT_3DES,

--- a/tests/Zend/Filter/Encrypt/McryptTest.php
+++ b/tests/Zend/Filter/Encrypt/McryptTest.php
@@ -94,8 +94,10 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
         $filter->setVector('testvect');
         $this->assertEquals(
             array('key' => 'testkey',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_BLOWFISH,
                   'algorithm_directory' => '',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_CBC,
                   'mode_directory' => '',
                   'vector' => 'testvect',
@@ -114,12 +116,16 @@ class Zend_Filter_Encrypt_McryptTest extends PHPUnit_Framework_TestCase
         $filter = new Zend_Filter_Encrypt_Mcrypt(array('key' => 'testkey'));
         $filter->setVector('testvect');
         $filter->setEncryption(
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
         $this->assertEquals(
             array('key' => 'testkey',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES,
                   'algorithm_directory' => '',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_ECB,
                   'mode_directory' => '',
                   'vector' => 'testvect',

--- a/tests/Zend/Filter/EncryptTest.php
+++ b/tests/Zend/Filter/EncryptTest.php
@@ -146,7 +146,7 @@ PIDs9E7uuizAKDhRRRvho8BS
 
         $filter = new Zend_Filter_Encrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
                   'algorithm' => MCRYPT_BLOWFISH,
@@ -172,11 +172,11 @@ PIDs9E7uuizAKDhRRRvho8BS
 
         $filter = new Zend_Filter_Encrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $filter->setEncryption(
             array('mode' => MCRYPT_MODE_ECB,
                   'algorithm' => MCRYPT_3DES));
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
                   'algorithm' => MCRYPT_3DES,

--- a/tests/Zend/Filter/EncryptTest.php
+++ b/tests/Zend/Filter/EncryptTest.php
@@ -148,8 +148,10 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter->setVector('testvect');
         $this->assertEquals(
             array('key' => 'testkey',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_BLOWFISH,
                   'algorithm_directory' => '',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_CBC,
                   'mode_directory' => '',
                   'vector' => 'testvect',
@@ -172,12 +174,16 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter = new Zend_Filter_Encrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
         $filter->setEncryption(
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
         $this->assertEquals(
             array('key' => 'testkey',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES,
                   'algorithm_directory' => '',
+                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_ECB,
                   'mode_directory' => '',
                   'vector' => 'testvect',

--- a/tests/Zend/Filter/EncryptTest.php
+++ b/tests/Zend/Filter/EncryptTest.php
@@ -146,12 +146,11 @@ PIDs9E7uuizAKDhRRRvho8BS
 
         $filter = new Zend_Filter_Encrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_BLOWFISH\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_BLOWFISH,
                   'algorithm_directory' => '',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_CBC\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_CBC,
                   'mode_directory' => '',
                   'vector' => 'testvect',
@@ -173,17 +172,15 @@ PIDs9E7uuizAKDhRRRvho8BS
 
         $filter = new Zend_Filter_Encrypt(array('adapter' => 'Mcrypt', 'key' => 'testkey'));
         $filter->setVector('testvect');
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $filter->setEncryption(
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
             array('mode' => MCRYPT_MODE_ECB,
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES));
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
         $this->assertEquals(
             array('key' => 'testkey',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_3DES\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'algorithm' => MCRYPT_3DES,
                   'algorithm_directory' => '',
-                  trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"MCRYPT_MODE_ECB\" is deprecated since PHP 7.1 and removed since PHP 7.2", E_USER_WARNING);
                   'mode' => MCRYPT_MODE_ECB,
                   'mode_directory' => '',
                   'vector' => 'testvect',

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -141,9 +141,9 @@ class Zend_Http_Client_CurlTest extends Zend_Http_Client_CommonHttpTests
      */
     public function testSettingInvalidCurlOption()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"CURLOPT_CLOSEPOLICY\" is removed since PHP 5.6", E_USER_WARNING);
         $config = array(
             'adapter'     => 'Zend_Http_Client_Adapter_Curl',
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"CURLOPT_CLOSEPOLICY\" is removed since PHP 5.6", E_USER_WARNING);
             'curloptions' => array(CURLOPT_CLOSEPOLICY => true),
         );
         $this->client = new Zend_Http_Client($this->client->getUri(true), $config);

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -143,6 +143,7 @@ class Zend_Http_Client_CurlTest extends Zend_Http_Client_CommonHttpTests
     {
         $config = array(
             'adapter'     => 'Zend_Http_Client_Adapter_Curl',
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"CURLOPT_CLOSEPOLICY\" is removed since PHP 5.6", E_USER_WARNING);
             'curloptions' => array(CURLOPT_CLOSEPOLICY => true),
         );
         $this->client = new Zend_Http_Client($this->client->getUri(true), $config);

--- a/tests/Zend/Http/Client/CurlTest.php
+++ b/tests/Zend/Http/Client/CurlTest.php
@@ -141,7 +141,7 @@ class Zend_Http_Client_CurlTest extends Zend_Http_Client_CommonHttpTests
      */
     public function testSettingInvalidCurlOption()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"CURLOPT_CLOSEPOLICY\" is removed since PHP 5.6", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The constant \"CURLOPT_CLOSEPOLICY\" is removed since PHP 5.6\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $config = array(
             'adapter'     => 'Zend_Http_Client_Adapter_Curl',
             'curloptions' => array(CURLOPT_CLOSEPOLICY => true),

--- a/tests/Zend/Http/Client/_files/testSimpleRequests.php
+++ b/tests/Zend/Http/Client/_files/testSimpleRequests.php
@@ -1,2 +1,1 @@
-trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: No PHP code was found in this file and short open tags are not allowed by this install of PHP.", E_USER_WARNING);
 Success

--- a/tests/Zend/Http/Client/_files/testSimpleRequests.php
+++ b/tests/Zend/Http/Client/_files/testSimpleRequests.php
@@ -1,1 +1,2 @@
+trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: No PHP code was found in this file and short open tags are not allowed by this install of PHP.", E_USER_WARNING);
 Success

--- a/tests/Zend/Service/Amazon/Authentication/S3Test.php
+++ b/tests/Zend/Service/Amazon/Authentication/S3Test.php
@@ -155,7 +155,7 @@ x-amz-date:Tue, 27 Mar 2007 21:20:26 +0000
         $headers['Content-MD5'] = "4gJE4saaMU4BqNR0kLY+lw==";
         $headers['X-Amz-Meta-ReviewedBy'][] = "joe@johnsmith.net";
         $headers['X-Amz-Meta-ReviewedBy'][] = "jane@johnsmith.net";
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $headers['X-Amz-Meta-FileChecksum'] = "0x02661779";
         $headers['X-Amz-Meta-ChecksumAlgorithm'] = "crc32";
         $headers['Content-Disposition'] = "attachment; filename=database.dat";

--- a/tests/Zend/Service/Amazon/Authentication/S3Test.php
+++ b/tests/Zend/Service/Amazon/Authentication/S3Test.php
@@ -155,6 +155,7 @@ x-amz-date:Tue, 27 Mar 2007 21:20:26 +0000
         $headers['Content-MD5'] = "4gJE4saaMU4BqNR0kLY+lw==";
         $headers['X-Amz-Meta-ReviewedBy'][] = "joe@johnsmith.net";
         $headers['X-Amz-Meta-ReviewedBy'][] = "jane@johnsmith.net";
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
         $headers['X-Amz-Meta-FileChecksum'] = "0x02661779";
         $headers['X-Amz-Meta-ChecksumAlgorithm'] = "crc32";
         $headers['Content-Disposition'] = "attachment; filename=database.dat";

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -1075,6 +1075,7 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
     public function testInvalidPreexistingSessionIdDoesNotPreventRegenerationOfSid()
     {
         // Pattern: [0-9a-v]*
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1", E_USER_WARNING);
         ini_set('session.hash_bits_per_character', 5);
 
         // Session store

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -1075,7 +1075,7 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
     public function testInvalidPreexistingSessionIdDoesNotPreventRegenerationOfSid()
     {
         // Pattern: [0-9a-v]*
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: INI directive 'session.hash_bits_per_character' is removed since PHP 7.1\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         ini_set('session.hash_bits_per_character', 5);
 
         // Session store

--- a/tests/Zend/Validate/DigitsTest.php
+++ b/tests/Zend/Validate/DigitsTest.php
@@ -60,13 +60,13 @@ class Zend_Validate_DigitsTest extends PHPUnit_Framework_TestCase
      */
     public function testExpectedResultsWithBasicInputValues()
     {
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
         $valuesExpected = array(
             'abc123'  => false,
             'abc 123' => false,
             'abcxyz'  => false,
             'AZ@#4.3' => false,
             '1.23'    => false,
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
             '0x9f'    => false,
             '123'     => true,
             '09'      => true,

--- a/tests/Zend/Validate/DigitsTest.php
+++ b/tests/Zend/Validate/DigitsTest.php
@@ -60,7 +60,7 @@ class Zend_Validate_DigitsTest extends PHPUnit_Framework_TestCase
      */
     public function testExpectedResultsWithBasicInputValues()
     {
-        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
+        trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
         $valuesExpected = array(
             'abc123'  => false,
             'abc 123' => false,

--- a/tests/Zend/Validate/DigitsTest.php
+++ b/tests/Zend/Validate/DigitsTest.php
@@ -66,6 +66,7 @@ class Zend_Validate_DigitsTest extends PHPUnit_Framework_TestCase
             'abcxyz'  => false,
             'AZ@#4.3' => false,
             '1.23'    => false,
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tERROR: The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7.", E_USER_WARNING);
             '0x9f'    => false,
             '123'     => true,
             '09'      => true,

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -62,6 +62,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', $this->_origEncoding);
         } else {
             ini_set('default_charset', $this->_origEncoding);
@@ -368,6 +369,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function testDifferentIconvEncoding()
     {
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'ISO8859-1');
         } else {
             ini_set('default_charset', 'ISO8859-1');

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -62,7 +62,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', $this->_origEncoding);
         } else {
             ini_set('default_charset', $this->_origEncoding);
@@ -369,7 +369,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function testDifferentIconvEncoding()
     {
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'ISO8859-1');
         } else {
             ini_set('default_charset', 'ISO8859-1');

--- a/tests/Zend/Validate/StringLengthTest.php
+++ b/tests/Zend/Validate/StringLengthTest.php
@@ -60,6 +60,7 @@ class Zend_Validate_StringLengthTest extends PHPUnit_Framework_TestCase
     public function testBasic()
     {
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('default_charset', 'UTF-8');
@@ -166,6 +167,7 @@ class Zend_Validate_StringLengthTest extends PHPUnit_Framework_TestCase
     public function testDifferentEncodingWithValidator()
     {
         if (PHP_VERSION_ID < 50600) {
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('default_charset', 'UTF-8');

--- a/tests/Zend/Validate/StringLengthTest.php
+++ b/tests/Zend/Validate/StringLengthTest.php
@@ -60,7 +60,7 @@ class Zend_Validate_StringLengthTest extends PHPUnit_Framework_TestCase
     public function testBasic()
     {
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('default_charset', 'UTF-8');
@@ -167,7 +167,7 @@ class Zend_Validate_StringLengthTest extends PHPUnit_Framework_TestCase
     public function testDifferentEncodingWithValidator()
     {
         if (PHP_VERSION_ID < 50600) {
-            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.", E_USER_WARNING);
+            trigger_error("PHP 7.2 Compatibility Alert:\n\tWARNING: All previously accepted values for the \$type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.\n\t".implode("\n\t", array_map(function ($item) { return sprintf("%s::%s", $item['file'], $item['line']); }, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS))), E_USER_WARNING);
             iconv_set_encoding('internal_encoding', 'UTF-8');
         } else {
             ini_set('default_charset', 'UTF-8');


### PR DESCRIPTION
Placing an E_USER_WARNING for every line of code that was reported as a PHP 7.2 compatibility ERROR and WARNING, in order to identify whether any of these concerns apply to our use of zendframework1.

* Deployed to DEV - a kibana viz at https://vpc-dt-logging-dev-ghfj7fl7hi6whsw2g36vc4npuy.us-east-1.es.amazonaws.com/_plugin/kibana/app/kibana#/visualize/edit/bf55c120-6617-11e9-9a52-75a712bb9d50?_g=(refreshInterval%3A(pause%3A!f%2Cvalue%3A60000)%2Ctime%3A(from%3Anow-24h%2Cmode%3Aquick%2Cto%3Anow))
* Unit tests not passing on Travis
* Wondering what improvements/additional log message info we may want to include, if any