### PR TITLE
DTPORTAL-16910 support for fractional seconds in log timestamps

### DIFF
--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -345,7 +345,7 @@ class Zend_Log
     protected function _packEvent($message, $priority)
     {
         return array_merge(array(
-            'timestamp'    => date($this->_timestampFormat),
+            'timestamp'    => date_format(new DateTime(), $this->_timestampFormat),
             'message'      => $message,
             'priority'     => $priority,
             'priorityName' => $this->_priorities[$priority]


### PR DESCRIPTION
## [[ZF1-Future] adding milliseconds to log timestamps](https://dialogtech.atlassian.net/browse/DTPORTAL-16910)
This changes log message timestamp generation from using `date` (limited to full seconds) to using `date_format(DateTime)` (supports fractional seconds).