### PR TITLE
DTPORTAL-19381 re-sync socket request_timeout if was not initialized …

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -81,6 +81,13 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
     ];
 
     /**
+     * Whether the socket was created without a request_timeout, in which case we'll repeatedly sync it to timeout
+     *
+     * @var boolean
+     */
+    protected $config_request_timeout_passthrough = false;
+
+    /**
      * Request method - will be set by write() and might be used by read()
      *
      * @var string
@@ -238,7 +245,11 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
 
             //distinguish between request timeout and connect timeout like in curl adapter
             // request_timeout defaults to connection timeout to keep backwards compatibility
-            if(!array_key_exists('request_timeout', $this->config)) {
+            // if this socket ever lacked a request_timeout, then sync it to timeout
+            if (!array_key_exists('request_timeout', $this->config)) {
+                $this->config_request_timeout_passthrough = true;
+            }
+            if ($this->config_request_timeout_passthrough) {
                 $this->config['request_timeout'] = $this->config['timeout'];
             }
             


### PR DESCRIPTION
…independently

Seems the community made a change to have a new `request_timeout` config, that defaults to the value of `timeout`.

Our app throws them for a loop, because we re-use the socket with varying timeouts.

Bug was:

1. `timeout` of 1 set for us a `request_timeout` of 1 (b/c `request_timeout` was not set).
2. `timeout` of 117 did NOT reset our `request_timeout` (b/c `request_timeout` had been set to 1).
3. socket "timed out" b/c we ran out of the 1 second allotted for `request_timeout`, even though we intended to wait for the 117 seconds allotted to `timeout`.

Solution:
* Determine and store whether `request_timeout` is missing from the config.
* If `request_timeout` had been missing from the socket's config, then perpetually reset it to `timeout`.