### PR TITLE
DTPORTAL-19297 Set samesite Attributes in Cookies

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -327,9 +327,6 @@ class Zend_Session extends Zend_Session_Abstract
         } else {
             if (!self::$_unitTestEnabled) {
                 session_regenerate_id(true);
-
-                // Force Samesite cookie
-                self::sameSiteCookieWorkaroundPrePhp74();
             }
             self::$_regenerateIdState = 1;
         }
@@ -493,9 +490,6 @@ class Zend_Session extends Zend_Session_Abstract
             }
 
             $startedCleanly = session_start();
-
-            // Force Samesite cookie
-            self::sameSiteCookieWorkaroundPrePhp74();
 
             if (self::$_throwStartupExceptions) {
                 restore_error_handler();
@@ -927,26 +921,4 @@ class Zend_Session extends Zend_Session_Abstract
     {
         return parent::$_readable;
     }
-
-    /**
-     * @todo Remove definition and calls after upgrade to PHP 7.4
-     *
-     * This can be removed once we update to 7.4 or above as then
-     * we can use php.ini directive to achieve the same `session.cookie_samesite=None`
-     */
-    public static function sameSiteCookieWorkaroundPrePhp74()
-    {
-        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-            setcookie('IFBYPHONE', self::getId(), 0, '/; SameSite=None; HttpOnly; Secure');
-        } else {
-            setcookie('IFBYPHONE', self::getId(), [
-                'expires'  => 0,
-                'path'     => '/',
-                'secure'   => true,
-                'httponly' => true,
-                'samesite' => 'None'
-            ]);
-        }
-    }
-
 }


### PR DESCRIPTION
## [Set samesite Attributes in Cookies](https://dialogtech.atlassian.net/browse/DTPORTAL-19297)
Remove same-site functionality from code and add the `session.cookie_samesite = "None"` to php.ini file.

### Requires
* https://dialogtech.atlassian.net/browse/TECHOPS-5509
* PHP7.4

### Code Reviewers
@BMTTMC @tdupreeibp @gfaza 